### PR TITLE
example of the clean bucket config for adt

### DIFF
--- a/clean_bucket/adt/1993010100.yaml
+++ b/clean_bucket/adt/1993010100.yaml
@@ -1,0 +1,111 @@
+aws_s3:
+     adt.cryosat2:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/cryosat2.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/cryosat2/%Y/%m/iodav2/cryosat2.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.ers1:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/ers1.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/ers1/%Y/%m/iodav2/ers1.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.ers2:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/ers2.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/ers2/%Y/%m/iodav2/ers2.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.jason2:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/jason2.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/jason2/%Y/%m/iodav2/jason2.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.jason3:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/jason3.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/jason3/%Y/%m/iodav2/jason3.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.saral:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/saral.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/saral/%Y/%m/iodav2/saral.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+     adt.sentinel3a:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/sentinel3a.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/sentinel3a/%Y/%m/iodav2/sentinel3a.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.sentinel3b:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/sentinel3b.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/sentinel3b/%Y/%m/iodav2/sentinel3b.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+     adt.topex_poseidon:
+
+          # Define the path attributes.
+          local_path: !ENV ${WORKrnr}/${EXPTrnr}/${CYCLE}/intercom/inputs/obs/ocean/topex_poseidon.adt.iodav2.nc
+          offset_seconds: 21600
+
+          # Define the AWS s3 attributes.
+          bucket: noaa-reanalyses-pds
+          object_path: observations/reanalysis/adt/topex_poseidon/%Y/%m/iodav2/topex_poseidon.adt.%Y%m%d.T120000Z.iodav2.nc
+          profile_name: Null
+          ignore_missing: True
+
+# ----
+
+globus: Null

--- a/clean_bucket/adt/readme
+++ b/clean_bucket/adt/readme
@@ -1,0 +1,4 @@
+absolute dynamic topography
+
+19930101 000000  21000101 240000 cryosat2, er1, ers2, jason2, jason3, sara1, sentinel3a, sentinel3b, topex_posidon
+

--- a/clean_bucket/clean_bucket_yaml_format.yaml
+++ b/clean_bucket/clean_bucket_yaml_format.yaml
@@ -1,0 +1,56 @@
+# $$$ YAML DOCUMENTATION BLOCK
+
+# DESCRIPTION:
+
+# This YAML formatted file contains the Unified Forecasting System
+# (UFS) Reforecast and Reanalysis (RNR) file fetching information for
+# the various UFS-RNR application inputs.
+
+# ----
+
+# TABLE 1: SUPPORTED REMOTE LOCATIONS FROM WHICH TO FETCH:
+
+# The supported remote locations from which to fetch the respective
+# UFS-RNR application inputs (i.e., YAML keys) are as follows:
+
+# | Remote Name  | Description
+# | ------------ | -----------
+# |    aws_s3    | All Amazon Web Services (AWS) s3 file system retrievals.
+#
+# |   noaa_hpss  | All National Oceanic and Atmospheric Administration
+#                  (NOAA) High-Performance Storage System (HPSS)
+#                  retrievals.
+# |   globus     | All globus file transfer retrievals.
+
+# ----
+
+# TABLE 2: KEY AND VALUE PAIRS REQUIRED TO FETCH FROM A SPECIFIED
+# SUPPORTED REMOTE LOCATION:
+
+# For each supported remote location type, the following YAML key and
+# value pairs are required; descriptions for each supporte remove
+# location type are provided in subsequent tables/documentation.
+
+# |  YAML Key   | Description
+# | ----------  | -----------
+
+# | remote_path | This is the path to the respective file to be
+# |               fetched from the supported remote location; POSIX
+# |               compliant timestamp templating is supported.
+
+# | local_path  | This is the path to where the respective fetched file
+# |               is to be staged on the local platform; POSIX
+# |               compliant timestamp templating is supported.
+
+# ----
+
+# TABLE 3: AWS S3 YAML-FORMATTED KEY AND VALUE PAIR DESCRIPTIONS.
+
+# The following are the attributes required to collect files from a
+# remote AWS s3 file system.
+
+# |  YAML Key   | Description
+# | ----------  | -----------
+
+# ----
+


### PR DESCRIPTION
- created new directory `clean_bucket` that will hold yaml files for transferring data from the clean bucket to local directory. 
- created a doc file clean_bucket/adt/readme describing the layout of the yaml files. 
- created an example of the yaml file for the adt/ssh measurements clean_bucket/adt/1993010100.yaml
- clean_bucket/adt/1993010100.yaml is active from the date of 1993010100. similar to how satinfo files are configured. 
